### PR TITLE
Allow additional properties

### DIFF
--- a/alacritty/reference.json
+++ b/alacritty/reference.json
@@ -607,5 +607,5 @@
 			}
 		}
 	},
-	"additionalProperties": false
+	"additionalProperties": true
 }


### PR DESCRIPTION
Alacritty supports additional properties and yaml anchors in it's config file. This is useful for messing around with themes. [relevant issue](https://github.com/alacritty/alacritty/issues/2710)

I noticed nvim throwing an error on my custom themes definition while editing my alacritty config and was a little confused until I remembered I was using schemastore for validation and found this.